### PR TITLE
fix: time over 였던 첫번째 방법 수정

### DIFF
--- a/higherOrderFunction/primeFactorization.swift
+++ b/higherOrderFunction/primeFactorization.swift
@@ -1,9 +1,11 @@
 import Foundation
 
 func solution(_ n:Int) -> [Int] {
-  
     // max : 17ms memory : 16.4MB
     return (2...n).filter { n % $0 == 0 && isPrime($0) }
+  
+    // max : 20ms
+    //return (2...n).filter { n % $0 == 0 }.filter { isPrime($0) } 
         
     // time over 
     //return (2...n).filter { isPrime($0) }.filter { n % $0 == 0 } 


### PR DESCRIPTION
조건 로직 순서에서 차이가 남.

처음 : 소수를 뽑고 나눠지는 수 찾고
수정: 나눠지는 수 찾고, 소수를 뽑고
